### PR TITLE
#15 - fixes bug where previous month rollover was also highlighted if…

### DIFF
--- a/src/calendar/calendar-class.js
+++ b/src/calendar/calendar-class.js
@@ -412,15 +412,16 @@ class Calendar {
             const cellDate = calendarDateList[i];
             calendarDayCell.innerText = cellDate;
             calendarDayCell.tabIndex = "0";
-            // highlight the cell if it matches the current date
-            this._highlightIfCurrDate(calendarDayCell, cellDate);
-            // if it isn't the current month, gray it out
+            // if date isn't in the current displayed month, gray it out
             if (i < currMonthStartIdx || i >= nextMonthStartIdx) {
                 // gray out rollover dates for prev and next month that are displayed
                 calendarDayCell.classList.add(rolloverDateClass);
             } else {
-                // otherwise, don't gray it. Note: removing a class that isn't there does nothing
+                // otherwise, date is in displayedMonth
+                // don't gray it. Note: removing a class that isn't there does nothing
                 calendarDayCell.classList.remove(rolloverDateClass);
+                // highlight the cell if it matches the present date
+                this._highlightIfCurrDate(calendarDayCell, cellDate);
             }
         }
     }


### PR DESCRIPTION
There was a bug where if the current date is 05/30, and we're in may, the 04/30 rollover date was also highlighted. Fixed this by moving the highlight checker into the if statement for the non rollover months. 