### PR TITLE
Update README.md with link to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dev-journal
-
+[Go to app](./src/calendar/calendar.html) (if on github pages site)
 
 [GitHub Pages](https://cse110-sp24-group23.github.io/dev-journal/)
 


### PR DESCRIPTION
Github pages takes you to the readme, so the readme should link to the app to make the app accessible from github pages. Once issue #114 is done, please edit this link to point to `./src/landing/landing.html`, but for now, it should point to calendar.html. This is done so we have something to send before the application hosting is finalized.