### PR TITLE
#12, #110 added missing keyboard access

### DIFF
--- a/src/calendar/calendar.js
+++ b/src/calendar/calendar.js
@@ -36,6 +36,7 @@ function calendarFunctionality(calendar) {
 function addClickToDays(calendar) {
     const calendarDays = document.querySelectorAll(".js-calendar-day");
     for (let day of calendarDays) {
+        // Listen for click
         day.addEventListener("click", () => {
             let record;
             // Date of the Clicked Cell
@@ -52,6 +53,29 @@ function addClickToDays(calendar) {
             sessionStorage.setItem("current record", JSON.stringify(record));
             // Redirects to daily log page for clicked date
             window.location.href = "../daily-log/daily-log.html";
+        });
+        // Listen for Enter key for keyboards
+        day.addEventListener("keypress", (event) => {
+            if (event.key === "Enter") {
+                let record;
+                // Date of the Clicked Cell
+                const dateObject = calendar.getDateOfDayCell(day);
+
+                // Get Record Object corresponding to date (if it exists),
+                // Else make a new record object.
+                if (RecordsStorage.hasRecordByDate(dateObject)) {
+                    record = RecordsStorage.getRecordByDate(dateObject);
+                } else {
+                    record = new Record("log", { date: dateObject });
+                }
+                // Stores current record from the cell date into session storage
+                sessionStorage.setItem(
+                    "current record",
+                    JSON.stringify(record)
+                );
+                // Redirects to daily log page for clicked date
+                window.location.href = "../daily-log/daily-log.html";
+            }
         });
     }
 }

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -6,6 +6,7 @@ import { setStatusMDE, getStatusMDE } from "../backend-storage/mde-mode-api.js";
 function updateStatusMDE() {
     //select the checkbox input from the HTML
     const mdeCheckbox = document.querySelector(".js-mde-checkbox");
+    // Add listener for Click
     mdeCheckbox.addEventListener("click", () => {
         let statusMDE;
         //check its status
@@ -16,6 +17,21 @@ function updateStatusMDE() {
         }
         //update the status
         setStatusMDE(statusMDE);
+    });
+    // Add listener for spacebar key - it's what is default for checkboxes
+    mdeCheckbox.addEventListener("keypress", (event) => {
+        // check if spacebar pressed
+        if (event.key === " ") {
+            let statusMDE;
+            //check its status
+            if (mdeCheckbox.checked == true) {
+                statusMDE = true;
+            } else {
+                statusMDE = false;
+            }
+            //update the status
+            setStatusMDE(statusMDE);
+        }
     });
 }
 /**


### PR DESCRIPTION
calendar dates weren't "Enter"-able through the keyboard to access daily logs. Settings page checkbox for disabling MDE wasn't changing the localStorage MDE status via spacebar.