### PR TITLE
Fixing issue in JSDocs comment, causing doc generation to fail

### DIFF
--- a/src/calendar/calendar.js
+++ b/src/calendar/calendar.js
@@ -4,7 +4,7 @@ import { Record } from "../backend-storage/record-class.js";
 
 /**
  * Uses Calendar class from ./calendar-class.js to populate the month view and show the next
- * or previous month when you click the < or > buttons on the calendar page.
+ * or previous month when you click the left or right buttons on the calendar page.
  * Also highlights the current day and grays out the rollover dates from the prev/next month.
  *
  * @param {Calendar} calendar - The calendar object to be used for functionality.

--- a/src/calendar/calendar.js
+++ b/src/calendar/calendar.js
@@ -4,7 +4,7 @@ import { Record } from "../backend-storage/record-class.js";
 
 /**
  * Uses Calendar class from ./calendar-class.js to populate the month view and show the next
- * or previous month when you click the '<' or '>' buttons on the calendar page.
+ * or previous month when you click the < or > buttons on the calendar page.
  * Also highlights the current day and grays out the rollover dates from the prev/next month.
  *
  * @param {Calendar} calendar - The calendar object to be used for functionality.

--- a/src/calendar/calendar.js
+++ b/src/calendar/calendar.js
@@ -4,7 +4,7 @@ import { Record } from "../backend-storage/record-class.js";
 
 /**
  * Uses Calendar class from ./calendar-class.js to populate the month view and show the next
- * or previous month when you click the `<` or `>` buttons on the calendar page.
+ * or previous month when you click the '<' or '>' buttons on the calendar page.
  * Also highlights the current day and grays out the rollover dates from the prev/next month.
  *
  * @param {Calendar} calendar - The calendar object to be used for functionality.


### PR DESCRIPTION
In `calendar.js`, had the code snippet:
`"...or previous month when you click the < or > buttons on the calendar page."`
in a comment. However, JSDocs would try to parse the left and right arrows, causing the documentation generation to crash. 
Thus I changed it to `left` and `right` respectively.

I see this as a documentation issue and not as a code issue, so I think this should circumnavigate the code freeze?